### PR TITLE
Task 10. Reordering of items via buttons that move items up or down the rank

### DIFF
--- a/SOLUTION.md
+++ b/SOLUTION.md
@@ -22,3 +22,15 @@ Task 9.
 
 I've removed the Add New Item link, but left the Create Item view and supporting code in-place as the New List functionality redirects there after creating a list.
 I've added a button 'create item' that is not triggered by pressing return, as I did not want any accidental creations - there is currently no way of removing a list. The user only needs to add the title, ownership defaults to the list owener, with medium importance and zero rank.
+
+Task 10.
+
+I've added up/down buttons to each item, that are only enabled when sorted by rank (cannot reorder rank properly when sorted by importance).
+Each item is now give a unique rank starting from 0.
+Any pre-existing data will need to be removed when running this version, as the code has been updated to give each item an incrementing rank starting from 0. This way, pressing the UP or DOWN button on each item simply swaps the rank with the sibling item, and resorts.
+As well as re-ordering on the page, an asychronous call is made to the controller to swap the ranks in the database.
+Any pre-existing data will need to be removed before running this version, as the ability to edit the rank in the edit page has also been removed - the importance of maintaining a unique rank is paramount for this version of reordering to work.
+
+I could have made the LI elements draggable, but the requirements didn't state what was visually required. Also, this only requires swapping the ranks of two items, draggable elements would mean updating the ranks of potentially many records (though it is possible by using a double for the rank, or having the initial ranks spaced out).
+
+Issues: when creating an item, the spacing after the buttons is not correct (Chrome Version 109.0.5414.120, Edge Version 125.0.2535.79)

--- a/Todo/Services/ApplicationDbContextConvenience.cs
+++ b/Todo/Services/ApplicationDbContextConvenience.cs
@@ -24,6 +24,34 @@ namespace Todo.Services
             return ownedLists.ToList().Union(otherLists.ToList()).ToList();
         }
 
+        public static int NextRankForList(this ApplicationDbContext dbContext, int todoListId)
+        {
+            var count = dbContext.TodoItems
+                .Where(ti => ti.TodoListId == todoListId)
+                .Max(r => r.Rank);
+
+            return count+1;
+        }
+
+        public static bool SwapRanksForItems(this ApplicationDbContext dbContext, int item1Id, int item2Id)
+        {
+            TodoItem item1 = dbContext.SingleTodoItem(item1Id);
+            TodoItem item2 = dbContext.SingleTodoItem(item2Id);
+            if (item1==null || item2==null)
+            {
+                return false;
+            }
+
+            int item1Rank = item1.Rank;
+            item1.Rank = item2.Rank;
+            item2.Rank = item1Rank;
+
+            dbContext.Update(item1);
+            dbContext.Update(item2);
+            dbContext.SaveChanges();
+            return true;
+        }
+
         public static TodoList SingleTodoList(this ApplicationDbContext dbContext, int todoListId)
         {
             return dbContext.TodoLists.Include(tl => tl.Owner)

--- a/Todo/Views/TodoItem/Edit.cshtml
+++ b/Todo/Views/TodoItem/Edit.cshtml
@@ -31,8 +31,7 @@
 
             <div class="form-group">
                 <label asp-for="Rank"></label>
-                <input asp-for="Rank" />
-                <span asp-validation-for="Rank" class="text-danger"></span>
+                @Model.Rank
             </div>
 
             <div class="form-group">

--- a/Todo/Views/TodoList/Detail.cshtml
+++ b/Todo/Views/TodoList/Detail.cshtml
@@ -23,17 +23,17 @@
                     <input type="checkbox" id="hideDoneCheckbox" />Hide completed
                 </label>
             </div>
-            <a id="sortByImportance">
-                <strong>Sort by importance</strong>
+            <a id="sortByRank" style="font-weight:bold">
+                Sort by rank
             </a>
             <br/>
-            <a id="sortByRank">
-                <strong>Sort by rank</strong>
+            <a id="sortByImportance">
+                Sort by importance
             </a>
         </div>
         <ul class="list-group">
             @* If changing the sorting, update the javascript in the <script> block to represent what the default sort is on page load *@
-            @foreach (var item in Model.Items.OrderBy(m => m.Importance))
+            @foreach (var item in Model.Items.OrderBy(m => m.Rank))
             {
                 string contextualClass;
                 switch (item.Importance)
@@ -57,10 +57,17 @@
                 @* data-importance and data-rank are used to store item properties for sorting 
                     data-email is used to lookup display name from gravatar asynchronously
                 *@
-                <li class="list-group-item @contextualClass" name=@rowName data-importance="@item.Importance" data-rank="@item.Rank" data-email="@item.ResponsibleParty.Email">
+                <li class="list-group-item @contextualClass" name=@rowName data-importance="@item.Importance" data-rank="@item.Rank" data-email="@item.ResponsibleParty.Email" data-itemId="@item.TodoItemId">
 
                     <div class="row">
                         <div class="col-md-8">
+                            <button type="button" class="btn btn-default" aria-label="Move Rank Down" onclick="moveRankDown(event)">
+                                <span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span>
+                            </button>
+                            <button type="button" class="btn btn-default" aria-label="Move Rank Up" onclick="moveRankUp(event)">
+                                <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span>
+                            </button>
+
                             <a asp-action="Edit" asp-controller="TodoItem" asp-route-todoItemId="@item.TodoItemId">
 
                                 @if (item.IsDone)
@@ -107,11 +114,13 @@
     const hideDoneCheckbox = document.getElementById("hideDoneCheckbox")
     const sortByRank = document.getElementById("sortByRank")
     const sortByImportance = document.getElementById("sortByImportance")
+    // Initial sorting is by rank.
+    rankingButtonsEnabled(true);
 
     loadProfileNames();
 
     // Initial sort on page load is importance/ascending
-    var sortedBy = "importance"
+    var sortedBy = "rank"
     var sortAscending = true;
 
     const collection = document.getElementsByName("isdone")
@@ -131,8 +140,11 @@
         else {
             sortedBy = "rank"
             sortAscending = true;
+            emphasiseAnchor(sortByRank, true);
+            emphasiseAnchor(sortByImportance, false);
         }
-        sortItems(sortAscending, sortByRankComparitor)
+        sortItems(sortAscending, sortByRankComparitor);
+        rankingButtonsEnabled(true);
     })
 
     sortByImportance.addEventListener('click', (event) => {
@@ -142,13 +154,15 @@
         else {
             sortedBy = "importance"
             sortAscending = true;
+            emphasiseAnchor(sortByRank, false);
+            emphasiseAnchor(sortByImportance, true);
         }
-        sortItems(sortAscending, sortByImportanceComparitor)
+        sortItems(sortAscending, sortByImportanceComparitor);
+        rankingButtonsEnabled(false);
     })
 
     function loadProfileNames() {
         let ul = $(".list-group:first");
-
 
         $.each(ul.children("li"), function (_, element) {
             let paragraph = element.getElementsByTagName("p")
@@ -253,13 +267,16 @@
         }
         let ul = $(".list-group:first");
 
-        let li = createNewListRow(titleText);
+        let liElement = createNewListRow(titleText);
+        if (sortedBy == "importance") {
+            disableRankingButtonsInsideLI(liElement, false);
+        }
 
-        ul.append(li);
+        ul.append(liElement);
 
-        let paragraph = li.getElementsByTagName("p");
-        let anchor = li.getElementsByTagName("a");
-        let emailAddr = li.getAttribute("data-email");
+        let paragraph = liElement.getElementsByTagName("p");
+        let anchor = liElement.getElementsByTagName("a");
+        let emailAddr = liElement.getAttribute("data-email");
 
         titleElement.value = "";
 
@@ -267,14 +284,19 @@
             setProfileName(paragraph[0], emailAddr);
         }
 
-        createItemAsync(@Model.TodoListId, titleText, "@Model.OwnerId", anchor[0]);
+        createItemAsync(@Model.TodoListId, titleText, "@Model.OwnerId", anchor[0], liElement);
 
         resort();
     }
 
-    function createItemAsync(todoListId, title, responsiblePartyId, anchorElement) {
-        $.post('@Url.Action("CreateItem")', { "listId":todoListId, title, responsiblePartyId}, function (itemId) {
-            anchorElement.setAttribute("href", "/TodoItem/Edit?todoItemId="+itemId);
+    function createItemAsync(todoListId, title, responsiblePartyId, anchorElement, liElement) {
+        $.post('@Url.Action("CreateItem")', { "listId":todoListId, title, responsiblePartyId}, function (item) {
+            anchorElement.setAttribute("href", "/TodoItem/Edit?todoItemId=" + item.todoItemId);
+            // Used when moving an item up/down a rank - item ids used to swap the rank in the backend
+            liElement.setAttribute("data-itemId", item.todoItemId);
+            // Used for sorting by rank
+            liElement.setAttribute("data-rank", item.rank);
+            resort();
         });
 
         resort();
@@ -290,17 +312,32 @@
         let paragraphElement = document.createElement("p");
         let imageElement = document.createElement("img");
         let textElement = document.createElement("text");
+        let buttonRankDownElement = document.createElement("button");
+        let buttonRankUpElement = document.createElement("button");
+        let buttonRankDownSpanElement = document.createElement("span");
+        let buttonRankUpSpanElement = document.createElement("span");
 
         textElement.innerText = titleText;
 
         // Anchor element will need to have its href attribute set after this item is created in the database
-
         imageElement.setAttribute("src", "https://www.gravatar.com/avatar/@Gravatar.GetHash(@Model.OwnerEmail)?s=30");
 
         // During tests, a plus sign was causing issues inside an email address. Javascripts unescape is deprecated.
         let email = "@Model.OwnerEmail";
         let unescapedEmail = email.replace("&#x2B;", "+");
         smallElement.innerText = unescapedEmail;
+
+        buttonRankDownSpanElement.setAttribute("class", "glyphicon glyphicon-chevron-up");
+        buttonRankDownSpanElement.setAttribute("aria-hidden", "true");
+        buttonRankUpSpanElement.setAttribute("class", "glyphicon glyphicon-chevron-down");
+        buttonRankUpSpanElement.setAttribute("aria-hidden", "true");
+
+        buttonRankDownElement.setAttribute("type", "button");
+        buttonRankDownElement.setAttribute("class", "btn btn-default");
+        buttonRankDownElement.setAttribute("aria-label", "Move Rank Down");
+        buttonRankUpElement.setAttribute("type", "button");
+        buttonRankUpElement.setAttribute("class", "btn btn-default");
+        buttonRankUpElement.setAttribute("aria-label", "Move Rank Up");
 
         subDivElement1.setAttribute("class", "col-md-8");
         subDivElement2.setAttribute("class", "col-md-4 text-right");
@@ -317,11 +354,104 @@
         subDivElement2.append(smallElement);
         subDivElement2.append(paragraphElement);
         anchorElement.append(textElement);
+
+        buttonRankDownElement.append(buttonRankDownSpanElement);
+        buttonRankUpElement.append(buttonRankUpSpanElement);
+        subDivElement1.append(buttonRankDownElement);
+        subDivElement1.append(buttonRankUpElement);
         subDivElement1.append(anchorElement);
         divElement.append(subDivElement1);
         divElement.append(subDivElement2);
         liElement.append(divElement);
 
+        buttonRankDownElement.addEventListener('click', moveRankDown);
+        buttonRankUpElement.addEventListener('click', moveRankUp);
+
         return liElement;
-    }   
+    }
+
+    function moveRankDown(event) {
+        if (sortedBy != "rank") {
+            return
+        }
+        let currentTarget = event.currentTarget
+        if (currentTarget != null) {
+            let containingListElement = currentTarget.parentElement.parentElement.parentElement;
+            let siblingListElement = containingListElement.previousElementSibling
+            if (siblingListElement != null) {
+                moveRank(containingListElement, siblingListElement);
+            }
+        }
+    }
+
+    function moveRankUp(event) {
+        if (sortedBy != "rank") {
+            return
+        }
+        let currentTarget = event.currentTarget
+        if (currentTarget != null) {
+            let containingListElement = currentTarget.parentElement.parentElement.parentElement;
+            let siblingListElement = containingListElement.nextElementSibling;
+            if (siblingListElement != null) {
+                moveRank(containingListElement, siblingListElement);
+            }
+        }
+    }
+
+    function moveRank(targetListElement, siblingListElement) {
+        let itemId = targetListElement.getAttribute("data-itemid");
+        if (itemId == null) {
+            return;
+        }
+        let itemRank = targetListElement.getAttribute("data-rank");
+        if (siblingListElement != null) {
+            let siblingId = siblingListElement.getAttribute("data-itemId");
+            if (siblingId == null) {
+                return
+            }
+            let swapWithRank = siblingListElement.getAttribute("data-rank");
+
+            targetListElement.setAttribute("data-rank", swapWithRank);
+            siblingListElement.setAttribute("data-rank", itemRank);
+
+            swapItemRanksAsync(itemId, siblingId);
+
+            resort();
+        }
+    }
+
+    function rankingButtonsEnabled(visible) {
+        let ul = $(".list-group:first");
+
+        $.each(ul.children("li"), function (_, liElement) {
+            disableRankingButtonsInsideLI(liElement, visible);
+        });
+    }
+
+    function disableRankingButtonsInsideLI(liElement, visible) {
+        let opacity = 0.2;
+        if (visible) {
+            opacity = 1.0;
+        }
+
+        let buttonElements = liElement.getElementsByTagName("button");
+        $.each(buttonElements, function (_, buttonElement) {
+            buttonElement.disabled = !visible;
+            buttonElement.style.opacity = opacity;
+        });
+    }
+
+    function swapItemRanksAsync(item1Id, item2Id) {
+        $.post('@Url.Action("SwapItemRanks")', { item1Id, item2Id });
+    }
+
+    function emphasiseAnchor(anchorElement, emphasise) {
+        if (emphasise) {
+            anchorElement.setAttribute("style", "font-weight:bold");
+        }
+        else {
+            anchorElement.setAttribute("style", "");
+        }
+    }
+
 </script>


### PR DESCRIPTION
Add
Ensure that any new items created have a rank 1 above the last existing rank.
Create a dbcontext convenience method that swaps the ranks of two items. 
Add up/down buttons to each item, that are enabled only when the sort-order is by rank. 
Ensure these are added when creating new items. 
Click function to swap ranks on-page and resort, and also asynchronously call the controller to swap them in the database.
Set default sort to Rank, and added emphasis to the selected sort order. Updated solution.md file to document this task.